### PR TITLE
Update local development dependency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ with `zig build`. otherwise, for macOS or non-X11 platforms use SDL2:
 
 ## local development
 
-you'll need [zig v0.11.x](https://ziglang.org/download/).
-if working on the gui, also [SDL2](https://www.libsdl.org/).
+you'll need [zig v0.12.x](https://ziglang.org/download/).
+if working on the gui using sdl2 driver, also [SDL2](https://www.libsdl.org/).
 
 note that compiling the daemon on macOS is currently unsupported since
 it requires some linux primitives.


### PR DESCRIPTION
Building with zig v0.11.0 gives error (caused by 281c3b6e1879d0b87318b6ab632a803393dafd26 I think, but I'm too lazy to test):

```
$ zig build
/home/user/git/ndg/build.zig.zon:5:17: error: dependency is missing 'url' field
        .nif = .{
                ^
/home/user/git/ndg/build.zig.zon:8:17: error: dependency is missing 'url' field
        .ini = .{
                ^
```

Also, SDL2 isn't anymore always required dependency for local development, since X11 support is added (btw, tested building and launching ngui with Ubuntu running under WSL2 under Windows 10, it worked).