### PR TITLE
Add GitHub Actions CI (second attempt)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+on: [push, pull_request]
+
+jobs:
+  build:
+      runs-on: ubuntu-latest
+
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+            fetch-tags: true
+        - name: Set up Zig
+          uses: goto-bus-stop/setup-zig@v2
+          with:
+            version: '0.12.1'
+        - name: Lint
+          run: ./tools/fmt-check.sh
+        - name: Test
+          run: zig build test
+        - name: Build SDL2
+          run: |
+            sudo apt-get install -y libsdl2-dev
+            zig build -Ddriver=sdl2
+        - name: Build X11
+          run: zig build -Ddriver=x11
+        - name: Build Aarch64
+          run: |
+            zig build -Ddriver=fbev -Dtarget=aarch64-linux-musl -Doptimize=ReleaseSafe -Dstrip
+            sha256sum zig-out/bin/nd zig-out/bin/ngui
+        - name: Playground
+          run: zig build guiplay btcrpc lndhc

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ the CI runs code format checks, tests and builds for fbdev+evdev on aarch64
 and SDL2. it requires a container image with zig and clang tools such as
 clang-format.
 
+there is now support for GitHub Actions, it's described in the
+[.github/workflows/ci.yml](.github/workflows/ci.yml) file.
+
+below are description for the original CI setup.
+
 to make a new image and switch the CI to use it, first modify the
 [ci-containerfile](tools/ci-containerfile) and produce the image locally:
 


### PR DESCRIPTION
In [previous attempt](https://github.com/nakamochi/ndg/pull/17) I had problems with fetching git tags and SemVer check, so tried to hack around with manual git checkout. Turns out `fetch-depth: 0` setting for `actions/checkout` was the right solution.