### PR TITLE
Fix LND REST calls

### DIFF
--- a/src/lightning/lndhttp.zig
+++ b/src/lightning/lndhttp.zig
@@ -149,7 +149,7 @@ pub const Client = struct {
         const opt = std.http.Client.RequestOptions{
             .redirect_behavior = .not_allowed, // no redirects in REST API
             .headers = reqinfo.stdheaders,
-            .privileged_headers = reqinfo.xheaders,
+            .extra_headers = reqinfo.xheaders,
             .server_header_buffer = &headersbuf,
         };
         var req = try self.httpClient.open(reqinfo.httpmethod, reqinfo.url, opt);


### PR DESCRIPTION
Fixes #33.

Not sure why. According to [Zig 0.12.1 documentation](https://ziglang.org/documentation/0.12.1/std/#std.http.Client.RequestOptions) both should work, as only difference is are headers stripped or kept when following redirects, but we explictly don't allow redirects. :man_shrugging: