### PR TITLE
Script to update live Nakamochi with locally built nd and ngui

### DIFF
--- a/tools/update-nakamochi.sh
+++ b/tools/update-nakamochi.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+if [[ -z $1 ]]; then
+    echo "Update Nakamochi with locally built nd and ngui."
+    echo "Usage: $(basename "$0") nakamochi-ip [binaries-path]"
+    echo "Where:"
+    echo "  nakamochi-ip      IP address of the Nakamochi device"
+    echo "  binaries-path     (Optional) Path to the directory containing 'nd' and 'ngui' binaries. Defaults to ./zig-out/bin."
+    exit 1
+fi
+
+NAKAMOCHI_IP=$1
+BINARIES_PATH=${2:-./zig-out/bin}
+
+if [[ ! -f "$BINARIES_PATH/nd" || ! -f "$BINARIES_PATH/ngui" ]]; then
+    echo "Could not find nd/ngui binaries in the specified path: $BINARIES_PATH"
+    exit 1
+fi
+
+ssh_cmd="ssh root@$NAKAMOCHI_IP"
+
+nakamochi_nd_path="$($ssh_cmd 'grep -o "/home/uiuser/v[0-9]\.[0-9]\.[0-9]" /etc/sv/nd/run | head -n 1')"
+if [[ -z $nakamochi_nd_path ]]; then
+    echo "Could not determine Nakamochi nd installation path."
+    exit 1
+fi
+
+$ssh_cmd "sha256sum $nakamochi_nd_path/*; sv stop nd" || { echo "Failed to stop nd service"; exit 1; }
+scp "$BINARIES_PATH/nd" "root@$NAKAMOCHI_IP:$nakamochi_nd_path/nd" || { echo "Failed to copy nd binary"; exit 1; }
+scp "$BINARIES_PATH/ngui" "root@$NAKAMOCHI_IP:$nakamochi_nd_path/ngui" || { echo "Failed to copy ngui binary"; exit 1; }
+$ssh_cmd "sha256sum $nakamochi_nd_path/*; sv start nd; grep ndg /var/log/socklog/daemon/current | tail" || { echo "Failed to start nd service"; exit 1; }
+
+echo "Nakamochi NDG update completed."


### PR DESCRIPTION
Useful for local testing before pushing binaries to any sysupdates channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a deployment tool to update Nakamochi devices with locally built binaries. It validates input and optional paths, checks required binaries exist, performs secure remote transfer, verifies integrity via checksums, and automates stopping and starting the service. It also provides log tailing to confirm successful deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->