### PR TITLE
CI: Add ShellCheck for shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
             fetch-depth: 0
             fetch-tags: true
             submodules: recursive
+        - name: Run ShellCheck
+          uses: ludeeus/action-shellcheck@master
+          with:
+            ignore_paths: lib
         - name: Verify submodules
           run: git submodule status --recursive
         - name: Set up Zig

--- a/tools/fmt-check.sh
+++ b/tools/fmt-check.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 zig fmt --check .
-C_FILES=$(find ./src -type f -name '*.c' ! -name 'lv_font*')
-clang-format -style=file -dry-run -Werror $C_FILES
+readarray -t C_FILES <<< "$(find ./src -type f -name '*.c' ! -name 'lv_font*')"
+clang-format -style=file -dry-run -Werror "${C_FILES[@]}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated ShellCheck step to the CI pipeline to run linting on shell scripts.
  * Improved the local formatting script: switched to bash, robustly handles file paths with spaces/newlines and passes files safely to the formatter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->