### PR TITLE
fbdev: support 16/32bpp framebuffer formats with runtime conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,13 @@ jobs:
           run: |
             sudo apt-get install -y libx11-dev
             zig build -Ddriver=x11
-        - name: Build Aarch64
+        - name: Build Aarch64 (Nakamochi)
           run: |
             zig build -Ddriver=fbev -Dtarget=aarch64-linux-musl -Doptimize=ReleaseSafe -Dstrip
+            sha256sum zig-out/bin/nd zig-out/bin/ngui
+        - name: Build Aarch64 (QEMU)
+          run: |
+            zig build -Ddriver=fbev -Dtarget=aarch64-linux-musl -Doptimize=ReleaseSafe -Dstrip -Dlv_color_depth=32
             sha256sum zig-out/bin/nd zig-out/bin/ngui
         - name: Playground
           run: zig build guiplay btcrpc lndhc

--- a/build.zig
+++ b/build.zig
@@ -7,8 +7,14 @@ pub fn build(b: *std.Build) void {
     const drv = b.option(DriverTarget, "driver", "display and input drivers combo; default: x11") orelse .x11;
     const disp_horiz = b.option(u32, "horiz", "display horizontal pixels count; default: 800") orelse 800;
     const disp_vert = b.option(u32, "vert", "display vertical pixels count; default: 480") orelse 480;
+    const lv_color_depth = b.option(u8, "lv_color_depth", "LVGL color depth, 16 or 32; default: 16") orelse 16;
+    const lv_color_16_swap = b.option(bool, "lv_color_16_swap", "Swap RGB565 bytes; default: false") orelse false;
     const lvgl_loglevel = b.option(LVGLLogLevel, "lvgl_loglevel", "LVGL lib logging level") orelse LVGLLogLevel.default(optimize);
     const inver = b.option([]const u8, "version", "semantic version of the build; must match git tag when available");
+
+    if (lv_color_depth != 16 and lv_color_depth != 32) {
+        @panic("lv_color_depth must be 16 or 32");
+    }
 
     const buildopts = b.addOptions();
     const buildopts_mod = buildopts.createModule();
@@ -43,6 +49,8 @@ pub fn build(b: *std.Build) void {
             .include_path = "lv_conf.h",
         },
         .{
+            .LV_COLOR_DEPTH = lv_color_depth,
+            .LV_COLOR_16_SWAP = @intFromBool(lv_color_16_swap),
             // string-like macro value, e.g. LV_LOG_LEVEL_WARN
             .LV_LOG_LEVEL = lvgl_loglevel.text(),
         },

--- a/src/ui/c/drv_fbev.c
+++ b/src/ui/c/drv_fbev.c
@@ -7,7 +7,13 @@
 #include "lvgl/lvgl.h"
 
 #include <fcntl.h>
+#include <linux/fb.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
 #include <unistd.h>
 #if USE_BSD_EVDEV
 #include <dev/evdev/input.h>
@@ -17,17 +23,241 @@
 
 #define DISP_BUF_SIZE (NM_DISP_HOR * NM_DISP_VER / 10)
 
+static int fb_fd = -1;
+static uint8_t *fb_mem = NULL;
+static size_t fb_mem_len = 0;
+static struct fb_fix_screeninfo fb_fix;
+static struct fb_var_screeninfo fb_var;
+
+static bool nm_fb_open(void)
+{
+    if (fb_fd != -1) {
+        return true;
+    }
+
+    fb_fd = open(FBDEV_PATH, O_RDWR);
+    if (fb_fd == -1) {
+        LV_LOG_WARN("open(%s) failed", FBDEV_PATH);
+        return false;
+    }
+    if (ioctl(fb_fd, FBIOGET_FSCREENINFO, &fb_fix) == -1) {
+        LV_LOG_WARN("FBIOGET_FSCREENINFO failed");
+        close(fb_fd);
+        fb_fd = -1;
+        return false;
+    }
+    if (ioctl(fb_fd, FBIOGET_VSCREENINFO, &fb_var) == -1) {
+        LV_LOG_WARN("FBIOGET_VSCREENINFO failed");
+        close(fb_fd);
+        fb_fd = -1;
+        return false;
+    }
+
+    fb_mem_len = fb_fix.smem_len;
+    fb_mem = mmap(NULL, fb_mem_len, PROT_READ | PROT_WRITE, MAP_SHARED, fb_fd, 0);
+    if (fb_mem == MAP_FAILED) {
+        LV_LOG_WARN("mmap framebuffer failed");
+        fb_mem = NULL;
+        close(fb_fd);
+        fb_fd = -1;
+        return false;
+    }
+
+    LV_LOG_INFO("fbdev: %ux%u virt=%ux%u bpp=%u line=%u r=%u/%u g=%u/%u b=%u/%u a=%u/%u",
+        fb_var.xres,
+        fb_var.yres,
+        fb_var.xres_virtual,
+        fb_var.yres_virtual,
+        fb_var.bits_per_pixel,
+        fb_fix.line_length,
+        fb_var.red.offset,
+        fb_var.red.length,
+        fb_var.green.offset,
+        fb_var.green.length,
+        fb_var.blue.offset,
+        fb_var.blue.length,
+        fb_var.transp.offset,
+        fb_var.transp.length);
+    return true;
+}
+
+#if LV_COLOR_DEPTH == 16 && LV_COLOR_16_SWAP
+static inline uint16_t nm_bswap16(uint16_t v)
+{
+    return (uint16_t)((v << 8) | (v >> 8));
+}
+#endif
+
+static inline uint32_t nm_mask_u32(uint32_t len)
+{
+    return (len >= 32u) ? UINT32_MAX : ((1u << len) - 1u);
+}
+
+#if LV_COLOR_DEPTH == 32
+static inline uint32_t nm_lv32_to_fb32(uint32_t p)
+{
+    uint8_t r = (uint8_t)((p >> 16) & 0xff);
+    uint8_t g = (uint8_t)((p >> 8) & 0xff);
+    uint8_t b = (uint8_t)(p & 0xff);
+
+    uint32_t out = 0;
+    out |= ((uint32_t)r) << fb_var.red.offset;
+    out |= ((uint32_t)g) << fb_var.green.offset;
+    out |= ((uint32_t)b) << fb_var.blue.offset;
+    if (fb_var.transp.length) {
+        uint32_t a = nm_mask_u32(fb_var.transp.length);
+        out |= a << fb_var.transp.offset;
+    }
+    return out;
+}
+#endif
+
+#if LV_COLOR_DEPTH == 16
+static inline uint32_t nm_rgb565_to_fb32(uint16_t p)
+{
+#if LV_COLOR_16_SWAP
+    p = nm_bswap16(p);
+#endif
+    uint8_t r5 = (p >> 11) & 0x1f;
+    uint8_t g6 = (p >> 5) & 0x3f;
+    uint8_t b5 = p & 0x1f;
+
+    uint8_t r8 = (uint8_t)((r5 << 3) | (r5 >> 2));
+    uint8_t g8 = (uint8_t)((g6 << 2) | (g6 >> 4));
+    uint8_t b8 = (uint8_t)((b5 << 3) | (b5 >> 2));
+
+    uint32_t out = 0;
+    out |= ((uint32_t)r8) << fb_var.red.offset;
+    out |= ((uint32_t)g8) << fb_var.green.offset;
+    out |= ((uint32_t)b8) << fb_var.blue.offset;
+    if (fb_var.transp.length) {
+        uint32_t a = nm_mask_u32(fb_var.transp.length);
+        out |= a << fb_var.transp.offset;
+    }
+    return out;
+}
+#endif
+
+static void nm_fbdev_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
+{
+    if (!nm_fb_open() || fb_mem == NULL) {
+        lv_disp_flush_ready(drv);
+        return;
+    }
+
+    int32_t x1 = area->x1 < 0 ? 0 : area->x1;
+    int32_t y1 = area->y1 < 0 ? 0 : area->y1;
+    int32_t x2 = area->x2 >= (int32_t)fb_var.xres ? (int32_t)fb_var.xres - 1 : area->x2;
+    int32_t y2 = area->y2 >= (int32_t)fb_var.yres ? (int32_t)fb_var.yres - 1 : area->y2;
+
+    if (x1 > x2 || y1 > y2) {
+        lv_disp_flush_ready(drv);
+        return;
+    }
+
+    const int32_t w = x2 - x1 + 1;
+    const int32_t src_w = area->x2 - area->x1 + 1;
+    const int32_t src_x_off = x1 - area->x1;
+    const int32_t src_y_off = y1 - area->y1;
+
+#if LV_COLOR_DEPTH == 16
+    const uint16_t *src = (const uint16_t *)color_p;
+
+    if (fb_var.bits_per_pixel == 16 && fb_var.red.length == 5 && fb_var.red.offset == 11 &&
+        fb_var.green.length == 6 && fb_var.green.offset == 5 && fb_var.blue.length == 5 &&
+        fb_var.blue.offset == 0) {
+
+        for (int32_t y = y1; y <= y2; y++) {
+            uint32_t fb_y = (uint32_t)y + fb_var.yoffset;
+            uint32_t fb_x = (uint32_t)x1 + fb_var.xoffset;
+            uint8_t *dst_row = fb_mem + (size_t)fb_y * fb_fix.line_length + (size_t)fb_x * 2u;
+            const uint16_t *src_row =
+                src + (size_t)(src_y_off + (y - y1)) * (size_t)src_w + (size_t)src_x_off;
+#if LV_COLOR_16_SWAP
+            uint16_t *dst16 = (uint16_t *)dst_row;
+            for (int32_t x = 0; x < w; x++) {
+                dst16[x] = nm_bswap16(src_row[x]);
+            }
+#else
+            memcpy(dst_row, src_row, (size_t)w * sizeof(uint16_t));
+#endif
+        }
+    } else if (fb_var.bits_per_pixel == 32) {
+        for (int32_t y = y1; y <= y2; y++) {
+            uint32_t fb_y = (uint32_t)y + fb_var.yoffset;
+            uint32_t fb_x = (uint32_t)x1 + fb_var.xoffset;
+            uint32_t *dst32 =
+                (uint32_t *)(fb_mem + (size_t)fb_y * fb_fix.line_length + (size_t)fb_x * 4u);
+            const uint16_t *src_row =
+                src + (size_t)(src_y_off + (y - y1)) * (size_t)src_w + (size_t)src_x_off;
+            for (int32_t x = 0; x < w; x++) {
+                dst32[x] = nm_rgb565_to_fb32(src_row[x]);
+            }
+        }
+    } else {
+        LV_LOG_WARN("unsupported fb format: src=16 dst=%ubpp", fb_var.bits_per_pixel);
+    }
+
+#elif LV_COLOR_DEPTH == 32
+    const uint32_t *src = (const uint32_t *)color_p;
+
+    if (fb_var.bits_per_pixel == 32 && fb_var.red.length == 8 && fb_var.green.length == 8 &&
+        fb_var.blue.length == 8) {
+
+        for (int32_t y = y1; y <= y2; y++) {
+            uint32_t fb_y = (uint32_t)y + fb_var.yoffset;
+            uint32_t fb_x = (uint32_t)x1 + fb_var.xoffset;
+            uint32_t *dst32 =
+                (uint32_t *)(fb_mem + (size_t)fb_y * fb_fix.line_length + (size_t)fb_x * 4u);
+            const uint32_t *src_row =
+                src + (size_t)(src_y_off + (y - y1)) * (size_t)src_w + (size_t)src_x_off;
+            for (int32_t x = 0; x < w; x++) {
+                dst32[x] = nm_lv32_to_fb32(src_row[x]);
+            }
+        }
+    } else if (fb_var.bits_per_pixel == 16 && fb_var.red.length == 5 && fb_var.red.offset == 11 &&
+               fb_var.green.length == 6 && fb_var.green.offset == 5 && fb_var.blue.length == 5 &&
+               fb_var.blue.offset == 0) {
+
+        for (int32_t y = y1; y <= y2; y++) {
+            uint32_t fb_y = (uint32_t)y + fb_var.yoffset;
+            uint32_t fb_x = (uint32_t)x1 + fb_var.xoffset;
+            uint16_t *dst16 =
+                (uint16_t *)(fb_mem + (size_t)fb_y * fb_fix.line_length + (size_t)fb_x * 2u);
+            const uint32_t *src_row =
+                src + (size_t)(src_y_off + (y - y1)) * (size_t)src_w + (size_t)src_x_off;
+            for (int32_t x = 0; x < w; x++) {
+                uint32_t p = src_row[x];
+                uint8_t r = (uint8_t)((p >> 16) & 0xff);
+                uint8_t g = (uint8_t)((p >> 8) & 0xff);
+                uint8_t b = (uint8_t)(p & 0xff);
+                uint16_t out = (uint16_t)(((r >> 3) & 0x1f) << 11) |
+                               (uint16_t)(((g >> 2) & 0x3f) << 5) |
+                               (uint16_t)(((b >> 3) & 0x1f) << 0);
+                dst16[x] = out;
+            }
+        }
+    } else {
+        LV_LOG_WARN("unsupported fb format: src=32 dst=%ubpp", fb_var.bits_per_pixel);
+    }
+#else
+#error Unsupported LV_COLOR_DEPTH
+#endif
+
+    lv_disp_flush_ready(drv);
+}
+
 /* returns NULL on error */
 lv_disp_t *nm_disp_init(void)
 {
-    fbdev_init();
+    if (!nm_fb_open()) {
+        return NULL;
+    }
 
     static lv_disp_draw_buf_t buf;
     static lv_color_t cb[DISP_BUF_SIZE];
     lv_disp_draw_buf_init(&buf, cb, NULL, DISP_BUF_SIZE);
-    uint32_t hor, vert;
-    fbdev_get_sizes(&hor, &vert, NULL);
-    if (hor != NM_DISP_HOR || vert != NM_DISP_VER) {
+    if (fb_var.xres != NM_DISP_HOR || fb_var.yres != NM_DISP_VER) {
         LV_LOG_WARN("framebuffer display mismatch; expected %dx%d", NM_DISP_HOR, NM_DISP_VER);
     }
 
@@ -37,7 +267,7 @@ lv_disp_t *nm_disp_init(void)
     disp_drv.hor_res = NM_DISP_HOR;
     disp_drv.ver_res = NM_DISP_VER;
     disp_drv.antialiasing = 1;
-    disp_drv.flush_cb = fbdev_flush;
+    disp_drv.flush_cb = nm_fbdev_flush;
     return lv_disp_drv_register(&disp_drv);
 }
 

--- a/src/ui/c/lv_conf.h.in
+++ b/src/ui/c/lv_conf.h.in
@@ -13,10 +13,10 @@
  *====================*/
 
 /*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 32 (ARGB8888)*/
-#define LV_COLOR_DEPTH 16
+#define LV_COLOR_DEPTH @LV_COLOR_DEPTH@
 
 /*Swap the 2 bytes of RGB565 color. Useful if the display has an 8-bit interface (e.g. SPI)*/
-#define LV_COLOR_16_SWAP 0
+#define LV_COLOR_16_SWAP @LV_COLOR_16_SWAP@
 
 /*Enable features to draw on transparent background.
  *It's required if opa, and transform_* style properties are used.


### PR DESCRIPTION
Add runtime framebuffer format detection and conversion in drv_fbev:
- support LV_COLOR_DEPTH=16 and 32 builds
- convert RGB565 <-> 32bpp using fb_var channel offsets
- respect framebuffer stride (line_length) to fix duplicated output
- handle common Linux fb formats (RGB565, XRGB8888, etc.)

Make helper functions conditional to avoid unused warnings:
- guard nm_bswap16 with LV_COLOR_DEPTH==16 && LV_COLOR_16_SWAP
- guard nm_rgb565_to_fb32 with LV_COLOR_DEPTH==16

This fixes incorrect colors and doubled output under QEMU while keeping fast path for native RGB565 framebuffer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build-time colour-depth choice (16 or 32) with runtime validation and option for 16-bit byte‑swap.
  * Selected colour options propagated into generated configuration headers.
  * Full framebuffer support with real‑time colour‑format conversion, alpha handling, bounds clipping and resolution checks.
* **Bug Fixes / Reliability**
  * Runtime safeguards and warnings when framebuffer cannot be opened or formats mismatch.
* **Chores**
  * CI: added a separate Aarch64 (QEMU) build step using the 32-bit colour option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->