### PR TITLE
feat(lightning): add LND watchtower client support

### DIFF
--- a/src/lightning/LndConf.zig
+++ b/src/lightning/LndConf.zig
@@ -216,6 +216,31 @@ pub fn alias(self: LndConf) []const u8 {
     };
 }
 
+/// returns a string property value from a section.
+/// sect_name must be lowercase (same requirement as findSection).
+/// if the key is repeated, returns the first value.
+pub fn getPropString(self: *const LndConf, sect_name: []const u8, key: []const u8) ?[]const u8 {
+    const sec = self.findSection(sect_name) orelse return null;
+    const val = sec.props.get(key) orelse return null;
+    return switch (val) {
+        .str => |s| s,
+        .astr => |a| if (a.len > 0) a[0] else null,
+    };
+}
+
+/// returns a bool property value from a section.
+/// accepted true values are: 1, true, yes, on.
+/// missing or unrecognized values return false.
+pub fn getPropBool(self: *const LndConf, sect_name: []const u8, key: []const u8) bool {
+    const val = self.getPropString(sect_name, key) orelse return false;
+    if (std.ascii.eqlIgnoreCase(val, "1") or std.ascii.eqlIgnoreCase(val, "true") or std.ascii.eqlIgnoreCase(val, "yes") or std.ascii.eqlIgnoreCase(val, "on")) return true;
+    return false;
+}
+
+pub fn wtClientActive(self: *const LndConf) bool {
+    return self.getPropBool("wtclient", "wtclient.active");
+}
+
 /// sets alias field value to the new name.
 /// the arg slice is owned by the caller and can be freed upon function return.
 pub fn setAlias(self: *LndConf, newname: []const u8) !void {
@@ -326,4 +351,33 @@ test "lnd: conf alias" {
         \\
     ;
     try t.expectEqualStrings(want_alias2, buf.items);
+}
+
+test "lnd: conf wtClientActive" {
+    const t = std.testing;
+
+    var conf = try LndConf.init(t.allocator);
+    defer conf.deinit();
+
+    try t.expect(!conf.wtClientActive());
+
+    var sec = try conf.appendSection("wtclient");
+    try sec.setPropStr("wtclient.active", "true");
+    try t.expect(conf.wtClientActive());
+
+    try sec.setPropStr("wtclient.active", "false");
+    try t.expect(!conf.wtClientActive());
+}
+
+test "lnd: conf getPropBool true values" {
+    const t = std.testing;
+
+    const vals: []const []const u8 = &.{ "1", "true", "TRUE", "yes", "on" };
+    for (vals) |v| {
+        var conf = try LndConf.init(t.allocator);
+        defer conf.deinit();
+        var sec = try conf.appendSection("wtclient");
+        try sec.setPropStr("wtclient.active", v);
+        try t.expect(conf.wtClientActive());
+    }
 }

--- a/src/lightning/lndhttp.zig
+++ b/src/lightning/lndhttp.zig
@@ -38,6 +38,7 @@ pub const Client = struct {
         walletbalance, // onchain balance
         // fwdinghistory, getchaninfo, getnodeinfo
         // watchtower: getinfo, stats, list, add, remove
+        addtower, // add a watchtower to wtclient
 
         fn apipath(self: @This()) []const u8 {
             return switch (self) {
@@ -46,6 +47,7 @@ pub const Client = struct {
                 .getinfo => "v1/getinfo",
                 .getnetworkinfo => "v1/graph/info",
                 .initwallet => "v1/initwallet",
+                .addtower => "v2/watchtower/client",
                 .listchannels => "v1/channels",
                 .pendingchannels => "v1/channels/pending",
                 .unlockwallet => "v1/unlockwallet",
@@ -65,6 +67,10 @@ pub const Client = struct {
                 //recovery_window: i32 = 0, // applies to each branch of BIP44 derivation path
                 //channel_backups
             },
+            .addtower => struct {
+                pubkey_hex: []const u8,
+                address: []const u8,
+            },
             .unlockwallet => struct {
                 unlock_password: []const u8, // from initwallet
                 // TODO: restore an existing wallet:
@@ -83,6 +89,7 @@ pub const Client = struct {
 
     pub fn ResultValue(comptime m: ApiMethod) type {
         return switch (m) {
+            .addtower => void,
             .feereport => FeeReport,
             .genseed => GeneratedSeed,
             .getinfo => LndInfo,
@@ -95,6 +102,24 @@ pub const Client = struct {
             .walletstatus => WalletStatus,
         };
     }
+
+    pub const Watchtower = struct {
+        pubkey_hex: []const u8,
+        address: []const u8,
+    };
+
+    pub const default_watchtowers = [_]Watchtower{
+        // https://lightningnetwork.plus/watchtower
+        .{
+            .pubkey_hex = "023bad37e5795654cecc69b43599da8bd5789ac633c098253f60494bde602b60bf",
+            .address = "iiu4epqzm6cydqhezueenccjlyzrqeruntlzbx47mlmdgfwgtrll66qd.onion:9911",
+        },
+        // https://vavok.net/bulltower_lightning_watchtower
+        .{
+            .pubkey_hex = "021cf043249acc0b497c6d8f291fd6fd18deba07f3c481777631bb469c6ea86446",
+            .address = "a6z5w3wiymr4je5py2hdvoknm26qyo4ghwmera2pod722nowou73uzid.onion:9911",
+        },
+    };
 
     pub const InitOpt = struct {
         allocator: std.mem.Allocator,
@@ -137,7 +162,7 @@ pub const Client = struct {
     }
 
     pub fn Result(comptime m: ApiMethod) type {
-        return if (@TypeOf(ResultValue(m)) == void) void else types.Deinitable(ResultValue(m));
+        return if (ResultValue(m) == void) void else types.Deinitable(ResultValue(m));
     }
 
     pub fn call(self: *Client, comptime apimethod: ApiMethod, args: MethodArgs(apimethod)) !Result(apimethod) {
@@ -170,7 +195,7 @@ pub const Client = struct {
             // TODO: return a more detailed error when the upstream improves.
             return Error.LndHttpBadStatusCode;
         }
-        if (@TypeOf(Result(apimethod)) == void) {
+        if (Result(apimethod) == void) {
             return; // void response; need no json parsing
         }
 
@@ -284,6 +309,34 @@ pub const Client = struct {
                 },
                 .payload = null,
             },
+            .addtower => |m| blk: {
+                const payload = p: {
+                    const pubkey_bytes = try hexDecodeAlloc(arena, args.pubkey_hex);
+                    const params: struct {
+                        pubkey: []const u8,
+                        address: []const u8,
+                    } = .{
+                        .pubkey = try base64EncodeAlloc(arena, pubkey_bytes),
+                        .address = args.address,
+                    };
+                    var buf = std.ArrayList(u8).init(arena);
+                    try std.json.stringify(params, .{ .emit_null_optional_fields = false }, buf.writer());
+                    break :p try buf.toOwnedSlice();
+                };
+                break :blk .{
+                    .httpmethod = .POST,
+                    .url = try std.Uri.parse(try std.fmt.allocPrint(arena, "{s}/{s}", .{ self.apibase, m.apipath() })),
+                    .xheaders = blk2: {
+                        if (self.macaroon.admin == null) {
+                            return Error.LndHttpMissingMacaroon;
+                        }
+                        var h = std.ArrayList(std.http.Header).init(arena);
+                        try h.append(.{ .name = authHeaderName, .value = self.macaroon.admin.? });
+                        break :blk2 try h.toOwnedSlice();
+                    },
+                    .payload = payload,
+                };
+            },
         };
         return reqinfo;
     }
@@ -305,6 +358,13 @@ pub const Client = struct {
     fn base64EncodeAlloc(gpa: std.mem.Allocator, v: []const u8) ![]const u8 {
         const buf = try gpa.alloc(u8, base64enc.calcSize(v.len));
         return base64enc.encode(buf, v); // always returns a slice of buf.len
+    }
+
+    fn hexDecodeAlloc(gpa: std.mem.Allocator, hex: []const u8) ![]u8 {
+        const buf = try gpa.alloc(u8, hex.len / 2);
+        errdefer gpa.free(buf);
+        _ = try std.fmt.hexToBytes(buf, hex);
+        return buf;
     }
 };
 

--- a/src/nd/Daemon.zig
+++ b/src/nd/Daemon.zig
@@ -1221,6 +1221,29 @@ fn initWallet(self: *Daemon, req: comm.Message.LightningInitWallet) !void {
     };
     res2.deinit(); // unused
 
+    const new_client = try lndhttp.Client.init(.{
+        .allocator = self.allocator,
+        .tlscert_path = Config.LND_TLSCERT_PATH,
+        .macaroon_admin_path = Config.LND_MACAROON_ADMIN_PATH,
+    });
+    client.deinit();
+    client = new_client;
+
+    logger.info("initwallet: configuring default watchtowers", .{});
+    for (lndhttp.Client.default_watchtowers) |tower| {
+        client.call(.addtower, .{
+            .pubkey_hex = tower.pubkey_hex,
+            .address = tower.address,
+        }) catch |err| {
+            logger.warn("initwallet: addtower {s}@{s}: {!}", .{
+                tower.pubkey_hex,
+                tower.address,
+                err,
+            });
+            continue;
+        };
+    }
+
     // same as above genLndConfig but with auto-unlock enabled.
     // no need to restart lnd: it'll pick up the new config on next boot.
     logger.info("initwallet: re-generating lnd config with auto-unlock", .{});


### PR DESCRIPTION
- add wtclient config helpers to LndConf (getPropBool, wtClientActive)
- extend lndhttp client with addtower API (POST /v2/watchtower/client)
- add default watchtower list (temporary hardcoded values)
- register watchtowers automatically after wallet initialization
- handle disabled wtclient gracefully (best-effort, non-fatal)

Also fix latent bug in Result() type handling:
- replace @TypeOf(...) == void with direct type comparison
- ensure void responses skip JSON parsing

Resolves #14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watchtower client support with automatic registration of default watchtowers during wallet initialisation.
  * API support to add a watchtower via its public key and address.
  * New configuration property queries to read string and boolean settings with robust true-value parsing.

* **Tests**
  * Extended unit tests covering watchtower activation defaults and accepted boolean string variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nakamochi/ndg/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->