### PR TITLE
ui/network: preserve selected WiFi SSID in dropdown

### DIFF
--- a/src/ngui.zig
+++ b/src/ngui.zig
@@ -16,7 +16,7 @@ const logger = std.log.scoped(.ngui);
 // these are auto-closed as soon as main fn terminates.
 const stderr = std.io.getStdErr().writer();
 
-extern "c" fn ui_update_network_status(text: [*:0]const u8, wifi_list: ?[*:0]const u8) void;
+extern "c" fn ui_update_network_status(text: [*:0]const u8, wifi_list: ?[*:0]const u8, active_ssid: ?[*:0]const u8) void;
 
 /// global heap allocator used throughout the GUI program.
 /// TODO: thread-safety?
@@ -226,15 +226,28 @@ test "writeDisplayIpAddr truncates long non-ipv4 addresses" {
     try writeDisplayIpAddr(buf.writer(), addr);
     try std.testing.expectEqualStrings("1234567890abcdef...90abcdef", buf.items);
 }
+
 /// callers must hold ui mutex for the whole duration.
 fn updateNetworkStatus(report: comm.Message.NetworkReport) !void {
     var wifi_list: ?[:0]const u8 = null;
     var wifi_list_ptr: ?[*:0]const u8 = null;
+
     if (report.wifi_scan_networks.len > 0) {
         wifi_list = try std.mem.joinZ(gpa, "\n", report.wifi_scan_networks);
         wifi_list_ptr = wifi_list.?.ptr;
     }
     defer if (wifi_list) |v| gpa.free(v);
+
+    var active_ssid: ?[:0]const u8 = null;
+    var active_ssid_ptr: ?[*:0]const u8 = null;
+
+    if (report.wifi_scan_networks.len > 0) {
+        if (report.wifi_ssid) |ssid| {
+            active_ssid = try gpa.dupeZ(u8, ssid);
+            active_ssid_ptr = active_ssid.?.ptr;
+        }
+    }
+    defer if (active_ssid) |v| gpa.free(v);
 
     var status = std.ArrayList(u8).init(gpa); // free'd as owned slice below
     const w = status.writer();
@@ -272,7 +285,7 @@ fn updateNetworkStatus(report: comm.Message.NetworkReport) !void {
 
     const text = try status.toOwnedSliceSentinel(0);
     defer gpa.free(text);
-    ui_update_network_status(text, wifi_list_ptr);
+    ui_update_network_status(text, wifi_list_ptr, active_ssid_ptr);
 
     // request network status again if we're connected but IP addr list is empty.
     // can happen with a fresh connection while dhcp is still in progress.

--- a/src/ui/c/ui.c
+++ b/src/ui/c/ui.c
@@ -8,6 +8,7 @@
 #include "lvgl/lvgl.h"
 
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 static lv_style_t style_title;
@@ -161,15 +162,50 @@ static struct {
     lv_obj_t *power_halt_btn_obj;   /* lv_btn_create */
 } settings;
 
+static void wifi_select_ssid(const char *ssid)
+{
+    if (ssid == NULL || ssid[0] == '\0') {
+        return;
+    }
+
+    const char *opts = lv_dropdown_get_options(settings.wifi_ssid_list_obj);
+    if (opts == NULL) {
+        return;
+    }
+
+    uint16_t idx = 0;
+    const char *p = opts;
+    const size_t ssid_len = strlen(ssid);
+    while (*p) {
+        const char *end = strchr(p, '\n');
+        size_t len = end ? (size_t)(end - p) : strlen(p);
+
+        if (ssid_len == len && memcmp(p, ssid, len) == 0) {
+            lv_dropdown_set_selected(settings.wifi_ssid_list_obj, idx);
+            return;
+        }
+
+        if (!end) {
+            break;
+        }
+
+        p = end + 1;
+        idx++;
+    }
+}
+
 /**
  * update the UI with network connection info, placing text into wifi_status_obj as is.
  * wifi_list is optional; items must be delimited by '\n' if non-null.
- * args are alloc-copied and owned by lvgl.
+ * text and wifi_list are alloc-copied and owned by lvgl.
+ * active_ssid is only read synchronously to select the current SSID and only
+ * needs to remain valid for the duration of this call.
  */
-extern void ui_update_network_status(const char *text, const char *wifi_list)
+extern void ui_update_network_status(const char *text, const char *wifi_list, const char *active_ssid)
 {
     if (wifi_list) {
         lv_dropdown_set_options(settings.wifi_ssid_list_obj, wifi_list);
+        wifi_select_ssid(active_ssid);
     }
     lv_obj_clear_state(settings.wifi_connect_btn_obj, LV_STATE_DISABLED);
     lv_obj_add_flag(settings.wifi_spinner_obj, LV_OBJ_FLAG_HIDDEN);


### PR DESCRIPTION
LVGL resets dropdown selection to index 0 when options are updated, causing the active WiFi network to appear incorrectly when entering settings or after refresh.

Fix by:
- passing active SSID from ngui to UI layer
- restoring selection after lv_dropdown_set_options()
- matching SSID against option list to select correct index

Result: WiFi dropdown now correctly reflects active/preconfigured network across tab switches and updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WiFi network status interface now displays and automatically selects the currently active network connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->