### PR TITLE
Debug log outgoing LND REST requests

### DIFF
--- a/src/lightning/lndhttp.zig
+++ b/src/lightning/lndhttp.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const base64enc = std.base64.standard.Encoder;
+const logger = std.log.scoped(.lndhttp);
 
 const types = @import("../types.zig");
 
@@ -156,6 +157,15 @@ pub const Client = struct {
         defer req.deinit();
         if (reqinfo.payload) |p| {
             req.transfer_encoding = .{ .content_length = p.len };
+        }
+
+        logger.debug("lnd request: {s} {}", .{ @tagName(reqinfo.httpmethod), reqinfo.url });
+        if (reqinfo.payload) |p| {
+            if (apimethod == .initwallet or apimethod == .unlockwallet) {
+                logger.debug("lnd request payload: <redacted> (len={d})", .{p.len});
+            } else {
+                logger.debug("lnd request payload: {s}", .{p});
+            }
         }
 
         try req.send();


### PR DESCRIPTION
Add debug logging for LND REST calls before they are sent, including the HTTP method, URL, and request payload when present. Avoid logging request headers so macaroon/auth material is not exposed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced debugging and troubleshooting capabilities with improved logging for Lightning Network node interactions, providing better visibility into request details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nakamochi/ndg/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->