### PR TITLE
fix: recover missing lnd wallet unlock config

### DIFF
--- a/src/nd/Daemon.zig
+++ b/src/nd/Daemon.zig
@@ -69,6 +69,8 @@ want_lnd_report: bool,
 lnd_timer: time.Timer,
 lnd_report_interval: u64 = 1 * time.ns_per_min,
 lnd_tls_reset_count: usize = 0,
+/// true after the daemon has tried the one-time recovery for a locked lnd wallet.
+lnd_wallet_unlock_recovery_attempted: bool = false,
 sysupdates_head_pulled: ?[]u8 = null,
 sysupdates_head_applied: ?[]u8 = null,
 next_head_refresh_ns: i128 = 0,
@@ -1097,15 +1099,113 @@ fn processLndReportError(self: *Daemon, err: anyerror) !void {
             self.want_lnd_report = false;
         },
         .LOCKED => {
-            try comm.write(self.allocator, self.uiwriter, msg_locked);
-            self.lnd_timer.reset();
-            self.want_lnd_report = false;
+            if (self.tryRecoverLockedLndWalletUnguarded()) {
+                switch (self.state) {
+                    .running, .standby => {
+                        try comm.write(self.allocator, self.uiwriter, msg_starting);
+                        self.lnd_timer.reset();
+                        self.want_lnd_report = true;
+                    },
+                    .stopped, .poweroff, .wallet_reset => {},
+                }
+                return;
+            }
+            switch (self.state) {
+                .running, .standby => {
+                    try comm.write(self.allocator, self.uiwriter, msg_locked);
+                    self.lnd_timer.reset();
+                    self.want_lnd_report = false;
+                },
+                .stopped, .poweroff, .wallet_reset => {},
+            }
         },
         .UNLOCKED, .RPC_ACTIVE, .WAITING_TO_START => comm.write(self.allocator, self.uiwriter, msg_starting),
         // active server indicates the lnd is ready to accept calls. so, the error
         // must have been due to factors other than unoperational lnd state.
         .SERVER_ACTIVE => err,
     };
+}
+
+/// Called after lnd reports a LOCKED wallet. The caller must hold self.mu,
+/// and this function returns with self.mu held. The actual filesystem and REST
+/// calls run without self.mu to avoid blocking other daemon operations and to
+/// avoid lock-order inversions with lnd config mutations.
+fn tryRecoverLockedLndWalletUnguarded(self: *Daemon) bool {
+    if (self.lnd_wallet_unlock_recovery_attempted) {
+        return false;
+    }
+    self.lnd_wallet_unlock_recovery_attempted = true;
+
+    self.mu.unlock();
+    defer self.mu.lock();
+
+    const recovered = self.tryRecoverLockedLndWalletUnlocked() catch |err| {
+        logger.err("lnd wallet unlock recovery: {!}", .{err});
+        return false;
+    };
+    return recovered;
+}
+
+/// Performs the one-time best-effort recovery for a locked lnd wallet when the
+/// wallet unlock password file exists but lnd.conf is missing the auto-unlock
+/// setting. Returns true only if the manual unlock REST call succeeds.
+fn tryRecoverLockedLndWalletUnlocked(self: *Daemon) !bool {
+    logger.warn("lnd wallet is locked; trying one-time recovery from {s}", .{Config.LND_WALLETUNLOCK_PATH});
+
+    const raw_pwd = std.fs.cwd().readFileAlloc(self.allocator, Config.LND_WALLETUNLOCK_PATH, 4096) catch |err| switch (err) {
+        error.FileNotFound => {
+            logger.warn("lnd wallet unlock recovery: {s} not found", .{Config.LND_WALLETUNLOCK_PATH});
+            return false;
+        },
+        else => {
+            logger.err("lnd wallet unlock recovery: read {s}: {!}", .{ Config.LND_WALLETUNLOCK_PATH, err });
+            return false;
+        },
+    };
+    defer self.allocator.free(raw_pwd);
+
+    const unlock_pwd = std.mem.trim(u8, raw_pwd, &std.ascii.whitespace);
+    if (unlock_pwd.len == 0) {
+        logger.err("lnd wallet unlock recovery: {s} is empty", .{Config.LND_WALLETUNLOCK_PATH});
+        return false;
+    }
+
+    var client = lndhttp.Client.init(.{
+        .allocator = self.allocator,
+        .tlscert_path = Config.LND_TLSCERT_PATH,
+    }) catch |err| {
+        logger.err("lnd wallet unlock recovery: client init: {!}", .{err});
+        return false;
+    };
+    defer client.deinit();
+
+    const res = client.call(.unlockwallet, .{ .unlock_password = unlock_pwd }) catch |err| {
+        logger.err("lnd wallet unlock recovery: unlockwallet: {!}", .{err});
+        return false;
+    };
+    res.deinit();
+
+    logger.info("lnd wallet unlock recovery: manual unlock succeeded", .{});
+    self.persistLndWalletUnlockPath() catch |err| {
+        logger.err("lnd wallet unlock recovery: persist auto-unlock config: {!}", .{err});
+    };
+    return true;
+}
+
+fn persistLndWalletUnlockPath(self: *Daemon) !void {
+    var mut = self.conf.beginMutateLndConf(.{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            logger.warn("lnd wallet unlock recovery: {s} not found; generating fresh lnd config", .{Config.LND_CONF_PATH});
+            return self.conf.genLndConfig(.{ .autounlock = true });
+        },
+        else => return err,
+    };
+    defer mut.finish();
+
+    const sec = mut.lndconf.mainSection() orelse try mut.lndconf.appendDefaultSection();
+    try sec.setPropStr("wallet-unlock-password-file", Config.LND_WALLETUNLOCK_PATH);
+    try mut.persist();
+    logger.info("lnd wallet unlock recovery: persisted wallet-unlock-password-file in {s}", .{Config.LND_CONF_PATH});
 }
 
 fn sendLightningPairingConn(self: *Daemon) !void {


### PR DESCRIPTION
If lnd reports the wallet as locked, attempt a one-time recovery using the local wallet unlock password file from LND_WALLETUNLOCK_PATH. On successful manual unlock, update lnd.conf with wallet-unlock-password-file so future starts can unlock normally.

This repairs cases where a partial lightning factory reset leaves the unlock password file present locally but removes the corresponding lnd config entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daemon now attempts automatic recovery when the wallet is locked, with intelligent fallback to previous behaviour if unsuccessful.
  * Interface reporting for locked wallet states has been improved with conditional scheduling of status updates.
  * Wallet auto-unlock configuration is now persisted across restarts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nakamochi/ndg/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->