### PR TITLE
Use 2500 address wallet recovery window

### DIFF
--- a/src/comm.zig
+++ b/src/comm.zig
@@ -249,11 +249,15 @@ pub const Message = union(MessageTag) {
 
     /// https://lightning.engineering/api-docs/api/lnd/wallet-unlocker/init-wallet
     pub const LightningInitWallet = struct {
+        pub const default_recovery_window: i32 = 2500;
+
         mnemonic: []const []const u8, // 24 words
         // TODO: support passphrase
         //passphrase: ?[]const u8,
 
-        // TODO: support extra fields for restoring an existing wallet, like recovery_window
+        // Non-zero only when restoring an existing wallet. This enables lnd's
+        // on-chain recovery scan and applies to each BIP44 branch.
+        recovery_window: i32 = 0,
     };
 
     pub const SysupdatesChan = enum(u8) {

--- a/src/lightning/lndhttp.zig
+++ b/src/lightning/lndhttp.zig
@@ -62,14 +62,15 @@ pub const Client = struct {
                 unlock_password: []const u8, // min 8 bytes
                 mnemonic: []const []const u8, // 24 words
                 passphrase: ?[]const u8 = null,
-                // TODO: restore an existing wallet:
-                //recovery_window: i32 = 0, // applies to each branch of BIP44 derivation path
+                // Address look-ahead for restoring an existing wallet. A zero
+                // value means no on-chain recovery scan should be attempted.
+                recovery_window: i32 = 0,
                 //channel_backups
             },
             .unlockwallet => struct {
                 unlock_password: []const u8, // from initwallet
-                // TODO: restore an existing wallet:
-                //recovery_window: i32 = 0, // applies to each branch of BIP44 derivation path
+                // Used to resume an interrupted recovery scan after lnd restart.
+                recovery_window: i32 = 0,
                 //channel_backups
             },
             .listchannels => struct {
@@ -219,10 +220,12 @@ pub const Client = struct {
                         wallet_password: []const u8, // base64
                         cipher_seed_mnemonic: []const []const u8,
                         aezeed_passphrase: ?[]const u8 = null, // base64
+                        recovery_window: i32,
                     } = .{
                         .wallet_password = try base64EncodeAlloc(arena, args.unlock_password),
                         .cipher_seed_mnemonic = args.mnemonic,
                         .aezeed_passphrase = if (args.passphrase) |p| try base64EncodeAlloc(arena, p) else null,
+                        .recovery_window = args.recovery_window,
                     };
                     var buf = std.ArrayList(u8).init(arena);
                     try std.json.stringify(params, .{ .emit_null_optional_fields = false }, buf.writer());
@@ -238,8 +241,10 @@ pub const Client = struct {
                 const payload = p: {
                     const params: struct {
                         wallet_password: []const u8, // base64
+                        recovery_window: i32,
                     } = .{
                         .wallet_password = try base64EncodeAlloc(arena, args.unlock_password),
+                        .recovery_window = args.recovery_window,
                     };
                     var buf = std.ArrayList(u8).init(arena);
                     try std.json.stringify(params, .{ .emit_null_optional_fields = false }, buf.writer());
@@ -317,6 +322,26 @@ pub const Client = struct {
         return base64enc.encode(buf, v); // always returns a slice of buf.len
     }
 };
+
+test "lndhttp: initwallet encodes recovery_window" {
+    const t = std.testing;
+    var client = Client{
+        .allocator = t.allocator,
+        .apibase = "https://localhost:10010",
+        .macaroon = .{ .readonly = null, .admin = null },
+        .httpClient = undefined,
+    };
+
+    const req = try client.formatreq(.initwallet, .{
+        .unlock_password = "password1",
+        .mnemonic = &.{"ability"},
+        .recovery_window = 2500,
+    });
+    defer req.deinit();
+
+    try t.expectEqual(std.http.Method.POST, req.value.httpmethod);
+    try t.expect(std.mem.indexOf(u8, req.value.payload.?, "\"recovery_window\":2500") != null);
+}
 
 /// general info and stats around the host lnd.
 pub const LndInfo = struct {

--- a/src/lightning/lndhttp.zig
+++ b/src/lightning/lndhttp.zig
@@ -34,6 +34,7 @@ pub const Client = struct {
         feereport, // fees of all active channels
         getinfo, // general host node info
         getnetworkinfo, // visible graph info
+        getrecoveryinfo, // lnd restore rescan progress
         listchannels, // active channels
         pendingchannels, // pending open/close channels
         walletbalance, // onchain balance
@@ -46,6 +47,7 @@ pub const Client = struct {
                 .genseed => "v1/genseed",
                 .getinfo => "v1/getinfo",
                 .getnetworkinfo => "v1/graph/info",
+                .getrecoveryinfo => "v1/getrecoveryinfo",
                 .initwallet => "v1/initwallet",
                 .listchannels => "v1/channels",
                 .pendingchannels => "v1/channels/pending",
@@ -89,6 +91,7 @@ pub const Client = struct {
             .genseed => GeneratedSeed,
             .getinfo => LndInfo,
             .getnetworkinfo => NetworkInfo,
+            .getrecoveryinfo => RecoveryInfo,
             .initwallet => InitedWallet,
             .listchannels => ChannelsList,
             .pendingchannels => PendingList,
@@ -269,6 +272,17 @@ pub const Client = struct {
                 },
                 .payload = null,
             },
+            .getrecoveryinfo => |m| .{
+                .httpmethod = .GET,
+                .url = try std.Uri.parse(try std.fmt.allocPrint(arena, "{s}/{s}", .{ self.apibase, m.apipath() })),
+                .xheaders = blk: {
+                    const macaroon = self.macaroon.readonly orelse self.macaroon.admin orelse return Error.LndHttpMissingMacaroon;
+                    var h = std.ArrayList(std.http.Header).init(arena);
+                    try h.append(.{ .name = authHeaderName, .value = macaroon });
+                    break :blk try h.toOwnedSlice();
+                },
+                .payload = null,
+            },
             .listchannels => .{
                 .httpmethod = .GET,
                 .url = blk: {
@@ -343,6 +357,42 @@ test "lndhttp: initwallet encodes recovery_window" {
     try t.expect(std.mem.indexOf(u8, req.value.payload.?, "\"recovery_window\":2500") != null);
 }
 
+test "lndhttp: getrecoveryinfo uses readonly macaroon" {
+    const t = std.testing;
+    var client = Client{
+        .allocator = t.allocator,
+        .apibase = "https://localhost:10010",
+        .macaroon = .{ .readonly = "readonlymac", .admin = "adminmac" },
+        .httpClient = undefined,
+    };
+
+    const req = try client.formatreq(.getrecoveryinfo, {});
+    defer req.deinit();
+
+    try t.expectEqual(std.http.Method.GET, req.value.httpmethod);
+    try t.expectEqual(@as(usize, 1), req.value.xheaders.len);
+    try t.expectEqualStrings("grpc-metadata-macaroon", req.value.xheaders[0].name);
+    try t.expectEqualStrings("readonlymac", req.value.xheaders[0].value);
+}
+
+test "lndhttp: getrecoveryinfo can fall back to admin macaroon" {
+    const t = std.testing;
+    var client = Client{
+        .allocator = t.allocator,
+        .apibase = "https://localhost:10010",
+        .macaroon = .{ .readonly = null, .admin = "adminmac" },
+        .httpClient = undefined,
+    };
+
+    const req = try client.formatreq(.getrecoveryinfo, {});
+    defer req.deinit();
+
+    try t.expectEqual(std.http.Method.GET, req.value.httpmethod);
+    try t.expectEqual(@as(usize, 1), req.value.xheaders.len);
+    try t.expectEqualStrings("grpc-metadata-macaroon", req.value.xheaders[0].name);
+    try t.expectEqualStrings("adminmac", req.value.xheaders[0].value);
+}
+
 /// general info and stats around the host lnd.
 pub const LndInfo = struct {
     version: []const u8,
@@ -363,6 +413,12 @@ pub const LndInfo = struct {
     },
     uris: []const []const u8,
     // best_header_timestamp and features?
+};
+
+pub const RecoveryInfo = struct {
+    recovery_mode: bool,
+    recovery_finished: bool,
+    progress: f64,
 };
 
 pub const NetworkInfo = struct {

--- a/src/nd/Config.zig
+++ b/src/nd/Config.zig
@@ -27,6 +27,8 @@ pub const LND_CONF_PATH = LND_HOMEDIR ++ "/lnd.mainnet.conf";
 pub const LND_TLSKEY_PATH = LND_HOMEDIR ++ "/.lnd/tls.key";
 pub const LND_TLSCERT_PATH = LND_HOMEDIR ++ "/.lnd/tls.cert";
 pub const LND_WALLETUNLOCK_PATH = LND_HOMEDIR ++ "/walletunlock.txt";
+/// Stores a non-zero wallet recovery window while an lnd restore rescan is pending.
+pub const LND_RECOVERY_WINDOW_PATH = LND_HOMEDIR ++ "/wallet-recovery-window.txt";
 pub const LND_MACAROON_RO_PATH = LND_DATA_DIR ++ "/chain/bitcoin/mainnet/readonly.macaroon";
 pub const LND_MACAROON_ADMIN_PATH = LND_DATA_DIR ++ "/chain/bitcoin/mainnet/admin.macaroon";
 
@@ -512,6 +514,44 @@ pub fn makeWalletUnlockFile(self: Config, outbuf: []u8, comptime raw_size: usize
     try self.chownLndUser(filepath);
 
     return hex;
+}
+
+/// Persists a non-zero lnd wallet recovery window until the recovery rescan finishes.
+pub fn writeLndRecoveryWindowFile(self: Config, recovery_window: i32) !void {
+    const filepath = LND_RECOVERY_WINDOW_PATH;
+    const allocator = self.arena.child_allocator;
+    const opt = .{ .mode = 0o400 };
+    const file = try std.io.BufferedAtomicFile.create(allocator, std.fs.cwd(), filepath, opt);
+    defer file.destroy(); // frees resources; does NOT delete the file
+
+    try std.fmt.format(file.writer(), "{d}\n", .{recovery_window});
+    try file.finish();
+    try self.chownLndUser(filepath);
+}
+
+/// Reads a pending lnd wallet recovery window. Null means no pending recovery window.
+pub fn readLndRecoveryWindowFile(_: Config) !?i32 {
+    var buf: [64]u8 = undefined;
+    const bytes = std.fs.cwd().readFile(LND_RECOVERY_WINDOW_PATH, &buf) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+
+    const trimmed = std.mem.trim(u8, bytes, &std.ascii.whitespace);
+    if (trimmed.len == 0) {
+        return null;
+    }
+
+    const recovery_window = try std.fmt.parseInt(i32, trimmed, 10);
+    return if (recovery_window > 0) recovery_window else null;
+}
+
+/// Removes the pending recovery-window marker.
+pub fn deleteLndRecoveryWindowFile() !void {
+    std.fs.cwd().deleteFile(LND_RECOVERY_WINDOW_PATH) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
 }
 
 /// options for genLndConfig.

--- a/src/nd/Daemon.zig
+++ b/src/nd/Daemon.zig
@@ -1030,6 +1030,8 @@ fn sendLightningReport(self: *Daemon) !void {
 
     lndrep.channels = channels.items;
     try comm.write(self.allocator, self.uiwriter, .{ .lightning_report = lndrep });
+
+    self.maybeFinishLndRecovery(&client);
 }
 
 /// evaluates any error returned from `sendLightningReport`.
@@ -1129,12 +1131,26 @@ fn processLndReportError(self: *Daemon, err: anyerror) !void {
 /// Called after lnd reports a LOCKED wallet. The caller must hold self.mu,
 /// and this function returns with self.mu held. The unlock file read and REST
 /// call run without self.mu; the follow-up auto-unlock config persist
-/// revalidates daemon state under self.mu before proceeding.
+/// revalidates daemon state under self.mu before proceeding. If a restore
+/// recovery-window marker exists, the manual unlock keeps passing it and
+/// auto-unlock remains disabled until lnd reports that recovery finished.
 fn tryRecoverLockedLndWalletUnguarded(self: *Daemon) bool {
-    if (self.lnd_wallet_unlock_recovery_attempted) {
+    const recovery_pending = if (self.conf.readLndRecoveryWindowFile() catch |err| {
+        logger.err("lnd wallet unlock recovery: read pending recovery window before retry decision: {!}", .{err});
         return false;
+    }) |_| true else false;
+
+    // The legacy broken-auto-unlock repair must only be attempted once: a bad
+    // local password should not be retried forever. A pending recovery marker
+    // is different: after a reboot or lnd restart during restore, the wallet
+    // must be unlocked again with the same recovery window until the rescan is
+    // actually finished and the marker is cleared.
+    if (!recovery_pending) {
+        if (self.lnd_wallet_unlock_recovery_attempted) {
+            return false;
+        }
+        self.lnd_wallet_unlock_recovery_attempted = true;
     }
-    self.lnd_wallet_unlock_recovery_attempted = true;
 
     self.mu.unlock();
     defer self.mu.lock();
@@ -1148,7 +1164,8 @@ fn tryRecoverLockedLndWalletUnguarded(self: *Daemon) bool {
 
 /// Performs the one-time best-effort recovery for a locked lnd wallet when the
 /// wallet unlock password file exists but lnd.conf is missing the auto-unlock
-/// setting. Returns true only if the manual unlock REST call succeeds.
+/// setting or an lnd restore scan needs to be resumed with a recovery window.
+/// Returns true only if the manual unlock REST call succeeds.
 fn tryRecoverLockedLndWalletUnlocked(self: *Daemon) !bool {
     logger.warn("lnd wallet is locked; trying one-time recovery from {s}", .{Config.LND_WALLETUNLOCK_PATH});
 
@@ -1179,13 +1196,29 @@ fn tryRecoverLockedLndWalletUnlocked(self: *Daemon) !bool {
     };
     defer client.deinit();
 
-    const res = client.call(.unlockwallet, .{ .unlock_password = unlock_pwd }) catch |err| {
+    const recovery_window = self.conf.readLndRecoveryWindowFile() catch |err| blk: {
+        logger.err("lnd wallet unlock recovery: read pending recovery window: {!}", .{err});
+        break :blk null;
+    };
+    if (recovery_window) |window| {
+        logger.info("lnd wallet unlock recovery: resuming recovery with recovery_window={d}", .{window});
+    }
+
+    const res = client.call(.unlockwallet, .{
+        .unlock_password = unlock_pwd,
+        .recovery_window = recovery_window orelse 0,
+    }) catch |err| {
         logger.err("lnd wallet unlock recovery: unlockwallet: {!}", .{err});
         return false;
     };
     res.deinit();
 
     logger.info("lnd wallet unlock recovery: manual unlock succeeded", .{});
+    if (recovery_window != null) {
+        logger.info("lnd wallet unlock recovery: delaying auto-unlock config until recovery finishes", .{});
+        return true;
+    }
+
     self.mu.lock();
     defer self.mu.unlock();
     if (!self.shouldPersistRecoveredLndWalletUnlockPath()) {
@@ -1222,6 +1255,50 @@ fn persistLndWalletUnlockPath(self: *Daemon) !void {
     try sec.setPropStr("wallet-unlock-password-file", Config.LND_WALLETUNLOCK_PATH);
     try mut.persist();
     logger.info("lnd wallet unlock recovery: persisted wallet-unlock-password-file in {s}", .{Config.LND_CONF_PATH});
+}
+
+/// Caller must hold self.mu so the state check before persisting
+/// auto-unlock and clearing the recovery marker is synchronized with shutdown
+/// and wallet-reset transitions.
+fn maybeFinishLndRecovery(self: *Daemon, client: *lndhttp.Client) void {
+    const pending_window = self.conf.readLndRecoveryWindowFile() catch |err| {
+        logger.err("lnd recovery: read pending recovery window: {!}", .{err});
+        return;
+    } orelse return;
+
+    const recinfo = client.call(.getrecoveryinfo, {}) catch |err| {
+        logger.err("lnd recovery: getrecoveryinfo: {!}", .{err});
+        return;
+    };
+    defer recinfo.deinit();
+
+    if (!recinfo.value.recovery_mode) {
+        logger.warn(
+            "lnd recovery: pending recovery_window={d} but lnd reports recovery_mode=false; treating as finished",
+            .{pending_window},
+        );
+    } else if (!recinfo.value.recovery_finished) {
+        logger.info("lnd recovery: scan progress {d:.2}%", .{recinfo.value.progress * 100});
+        return;
+    } else {
+        logger.info("lnd recovery: scan finished; enabling auto-unlock and clearing recovery window", .{});
+    }
+
+    if (!self.shouldPersistRecoveredLndWalletUnlockPath()) {
+        logger.warn(
+            "lnd recovery: skipping auto-unlock enable and pending recovery window cleanup while daemon state is {s}",
+            .{@tagName(self.state)},
+        );
+        return;
+    }
+
+    self.persistLndWalletUnlockPath() catch |err| {
+        logger.err("lnd recovery: enable auto-unlock: {!}", .{err});
+        return;
+    };
+    Config.deleteLndRecoveryWindowFile() catch |err| {
+        logger.err("lnd recovery: delete pending recovery window: {!}", .{err});
+    };
 }
 
 fn sendLightningPairingConn(self: *Daemon) !void {
@@ -1280,6 +1357,17 @@ fn initWallet(self: *Daemon, req: comm.Message.LightningInitWallet) !void {
         return Error.MakeWalletUnlockFileFail;
     };
 
+    if (req.recovery_window > 0) {
+        self.conf.writeLndRecoveryWindowFile(req.recovery_window) catch |err| {
+            logger.err("writeLndRecoveryWindowFile: {!}", .{err});
+            return Error.MakeWalletUnlockFileFail;
+        };
+    } else {
+        Config.deleteLndRecoveryWindowFile() catch |err| {
+            logger.err("delete stale lnd recovery window file: {!}", .{err});
+        };
+    }
+
     // commit the seed: initwallet needs no auth
     if (req.recovery_window > 0) {
         logger.info("initwallet: committing restored seed with recovery_window={d}", .{req.recovery_window});
@@ -1298,6 +1386,9 @@ fn initWallet(self: *Daemon, req: comm.Message.LightningInitWallet) !void {
             if (delerr != error.FileNotFound) {
                 logger.err("initwallet: delete stale wallet unlock file: {!}", .{delerr});
             }
+        };
+        Config.deleteLndRecoveryWindowFile() catch |delerr| {
+            logger.err("initwallet: delete stale recovery window file: {!}", .{delerr});
         };
         return switch (err) {
             error.LndHttpBadStatusCode => Error.InvalidSeedMnemonic,
@@ -1355,10 +1446,14 @@ fn initWallet(self: *Daemon, req: comm.Message.LightningInitWallet) !void {
     };
     res2.deinit(); // unused
 
-    // same as above genLndConfig but with auto-unlock enabled.
-    // no need to restart lnd: it'll pick up the new config on next boot.
-    logger.info("initwallet: re-generating lnd config with auto-unlock", .{});
-    try self.conf.genLndConfig(.{ .autounlock = true });
+    if (req.recovery_window > 0) {
+        logger.info("initwallet: delaying auto-unlock config until lnd recovery scan is finished", .{});
+    } else {
+        // same as above genLndConfig but with auto-unlock enabled.
+        // no need to restart lnd: it'll pick up the new config on next boot.
+        logger.info("initwallet: re-generating lnd config with auto-unlock", .{});
+        try self.conf.genLndConfig(.{ .autounlock = true });
+    }
 
     self.mu.lock();
     self.want_lnd_report = true; // trigger an immediate lnd report to update the UI
@@ -1400,7 +1495,11 @@ fn resetLndNode(self: *Daemon) !void {
     logger.info("resetLndNode: deleting lnd data", .{});
     try std.fs.cwd().deleteTree(Config.LND_DATA_DIR);
     try std.fs.cwd().deleteTree(Config.LND_LOG_DIR);
-    try std.fs.cwd().deleteFile(Config.LND_WALLETUNLOCK_PATH);
+    std.fs.cwd().deleteFile(Config.LND_WALLETUNLOCK_PATH) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+    try Config.deleteLndRecoveryWindowFile();
     if (std.fs.path.dirname(Config.LND_TLSCERT_PATH)) |dir| {
         try std.fs.cwd().deleteTree(dir);
     }

--- a/src/nd/Daemon.zig
+++ b/src/nd/Daemon.zig
@@ -1281,10 +1281,18 @@ fn initWallet(self: *Daemon, req: comm.Message.LightningInitWallet) !void {
     };
 
     // commit the seed: initwallet needs no auth
-    logger.info("initwallet: committing new seed and an unlock password", .{});
+    if (req.recovery_window > 0) {
+        logger.info("initwallet: committing restored seed with recovery_window={d}", .{req.recovery_window});
+    } else {
+        logger.info("initwallet: committing new seed and an unlock password", .{});
+    }
     var client = try lndhttp.Client.init(.{ .allocator = self.allocator, .tlscert_path = Config.LND_TLSCERT_PATH });
     defer client.deinit();
-    const res = client.call(.initwallet, .{ .unlock_password = unlock_pwd, .mnemonic = req.mnemonic }) catch |err| {
+    const res = client.call(.initwallet, .{
+        .unlock_password = unlock_pwd,
+        .mnemonic = req.mnemonic,
+        .recovery_window = req.recovery_window,
+    }) catch |err| {
         logger.err("lnd client initwallet: {!}", .{err});
         std.fs.cwd().deleteFile(Config.LND_WALLETUNLOCK_PATH) catch |delerr| {
             if (delerr != error.FileNotFound) {
@@ -1330,8 +1338,18 @@ fn initWallet(self: *Daemon, req: comm.Message.LightningInitWallet) !void {
 
     // unlock the wallet for the first time: required after initwallet.
     // it generates macaroon files and completes a wallet initialization.
-    logger.info("initwallet: unlocking new wallet for the first time", .{});
-    const res2 = client.call(.unlockwallet, .{ .unlock_password = unlock_pwd }) catch |err| {
+    if (req.recovery_window > 0) {
+        logger.info(
+            "initwallet: unlocking restored wallet for the first time with recovery_window={d}",
+            .{req.recovery_window},
+        );
+    } else {
+        logger.info("initwallet: unlocking new wallet for the first time", .{});
+    }
+    const res2 = client.call(.unlockwallet, .{
+        .unlock_password = unlock_pwd,
+        .recovery_window = req.recovery_window,
+    }) catch |err| {
         logger.err("lnd client unlockwallet: {!}", .{err});
         return Error.UnlockLndWallet;
     };

--- a/src/ui/lightning.zig
+++ b/src/ui/lightning.zig
@@ -515,7 +515,7 @@ fn confirmSetupSeed(mnemonic: []const []const u8) !void {
 }
 
 export fn nm_lnd_setup_commit_seed(_: *lvgl.LvEvent) callconv(.C) void {
-    setupCommitSeed() catch |err| logger.err("setupCommitSeed: {any}", .{err});
+    setupCommitSeed(0) catch |err| logger.err("setupCommitSeed: {any}", .{err});
 }
 
 fn restoreProceed() !void {
@@ -557,7 +557,7 @@ fn restoreProceed() !void {
     ss.mnemonic = try types.StringList.fromUnowned(alloc, normalized);
 
     widget.keyboardOff();
-    try setupCommitSeed();
+    try setupCommitSeed(comm.Message.LightningInitWallet.default_recovery_window);
 }
 
 fn showRestoreError(msg: [*:0]const u8) !void {
@@ -573,7 +573,7 @@ fn restoreErrModalCallback(_: usize) align(@alignOf(widget.ModalButtonCallbackFn
     preserve_main_active_tab();
 }
 
-fn setupCommitSeed() !void {
+fn setupCommitSeed(recovery_window: i32) !void {
     errdefer tab.destroySetup(); // TODO: display an error instead
     if (tab.seed_setup == null) {
         return error.LightningSetupInactive;
@@ -593,7 +593,10 @@ fn setupCommitSeed() !void {
     tab.wallet_init_ctrlconn_requested = false;
 
     tab.setMode(.startup);
-    try comm.pipeWrite(.{ .lightning_init_wallet = .{ .mnemonic = tab.seed_setup.?.mnemonic.?.items() } });
+    try comm.pipeWrite(.{ .lightning_init_wallet = .{
+        .mnemonic = tab.seed_setup.?.mnemonic.?.items(),
+        .recovery_window = recovery_window,
+    } });
 }
 
 fn setupPairing(conn: comm.Message.LightningCtrlConn) !void {


### PR DESCRIPTION
Same as default for lncli interactive wallet recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lightning wallet restoration support with an explicit recovery window during both initialization and unlock.
  * Added recovery-status handling using LND’s recovery info endpoint to detect when recovery is finished and then resume normal auto-unlock behaviour.
* **Bug Fixes**
  * Improved consistency of recovery window values across the restore flow, including clearer restored-vs-new behaviour.
  * Persist and clean up “recovery pending” state using an on-disk marker so recovery doesn’t get stuck and reset cleanup is more tolerant.
* **Tests**
  * Added unit coverage ensuring the recovery window is included in wallet setup/unlock requests and that LND requests use the correct macaroon source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->