### PR TITLE
Show lnd recovery progress on bitcoin tab

### DIFF
--- a/src/comm.zig
+++ b/src/comm.zig
@@ -179,6 +179,12 @@ pub const Message = union(MessageTag) {
             minfee: f32, // BTC/kvB
             fullrbf: bool,
         },
+        /// lnd wallet recovery status while an aezeed restore rescan is active.
+        /// During recovery the lnd wallet balance can be incomplete.
+        lnd_recovery: ?struct {
+            progress: f64, // 0.0-1.0
+        } = null,
+
         /// on-chain balance, all values in satoshis.
         /// may not be available due to disabled wallet, if bitcoin core is used,
         /// or lnd turned off/nonfunctional.

--- a/src/nd/Daemon.zig
+++ b/src/nd/Daemon.zig
@@ -809,6 +809,7 @@ fn sendOnchainReport(self: *Daemon) !void {
         stats.netinfo.deinit();
         stats.mempool.deinit();
         if (stats.balance) |bal| bal.deinit();
+        if (stats.recovery) |recinfo| recinfo.deinit();
     }
 
     const btcrep: comm.Message.OnchainReport = .{
@@ -835,6 +836,12 @@ fn sendOnchainReport(self: *Daemon) !void {
             .minfee = stats.mempool.value.mempoolminfee,
             .fullrbf = stats.mempool.value.fullrbf,
         },
+        .lnd_recovery = if (stats.recovery) |recinfo| blk: {
+            if (!recinfo.value.recovery_mode or recinfo.value.recovery_finished) {
+                break :blk null;
+            }
+            break :blk .{ .progress = recinfo.value.progress };
+        } else null,
         .balance = if (stats.balance) |bal| .{
             .source = .lnd,
             .total = bal.value.total_balance,
@@ -854,6 +861,8 @@ const OnchainStats = struct {
     mempool: bitcoindrpc.Client.Result(.getmempoolinfo),
     // lnd wallet may be uninitialized
     balance: ?lndhttp.Client.Result(.walletbalance),
+    // lnd wallet restore rescan status, when available
+    recovery: ?lndhttp.Client.Result(.getrecoveryinfo),
 };
 
 /// call site must hold self.mu due to self.state read access.
@@ -867,25 +876,28 @@ fn fetchOnchainStats(self: *Daemon) !OnchainStats {
     const netinfo = try client.call(.getnetworkinfo, {});
     const mempool = try client.call(.getmempoolinfo, {});
 
-    const balance: ?lndhttp.Client.Result(.walletbalance) = blk: { // lndhttp.WalletBalance
-        if (self.state == .wallet_reset) {
-            break :blk null;
-        }
+    var balance: ?lndhttp.Client.Result(.walletbalance) = null;
+    var recovery: ?lndhttp.Client.Result(.getrecoveryinfo) = null;
+    if (self.state != .wallet_reset) {
         var lndc = lndhttp.Client.init(.{
             .allocator = self.allocator,
             .tlscert_path = Config.LND_TLSCERT_PATH,
             .macaroon_ro_path = Config.LND_MACAROON_RO_PATH,
             .macaroon_admin_path = Config.LND_MACAROON_ADMIN_PATH,
-        }) catch break :blk null;
-        defer lndc.deinit();
-        const res = lndc.call(.walletbalance, {}) catch break :blk null;
-        break :blk res;
-    };
+        }) catch null;
+        if (lndc) |*lnd_client| {
+            defer lnd_client.deinit();
+            balance = lnd_client.call(.walletbalance, {}) catch null;
+            recovery = lnd_client.call(.getrecoveryinfo, {}) catch null;
+        }
+    }
+
     return .{
         .bcinfo = bcinfo,
         .netinfo = netinfo,
         .mempool = mempool,
         .balance = balance,
+        .recovery = recovery,
     };
 }
 

--- a/src/ui/bitcoin.zig
+++ b/src/ui/bitcoin.zig
@@ -23,6 +23,10 @@ var tab: struct {
     conn_in: lvgl.Label,
     conn_out: lvgl.Label,
     balance: struct {
+        recovery: struct {
+            row: lvgl.FlexLayout,
+            status: lvgl.Label,
+        },
         avail_bar: lvgl.Bar,
         avail_pct: lvgl.Label,
         total: lvgl.Label,
@@ -79,6 +83,21 @@ pub fn initTabPanel(cont: lvgl.Container) !void {
     // balance section
     {
         const card = try lvgl.Card.new(parent, "ON-CHAIN BALANCE", .{});
+        tab.balance.recovery.row = try lvgl.FlexLayout.new(card, .row, .{});
+        tab.balance.recovery.row.setWidth(lvgl.sizePercent(100));
+        tab.balance.recovery.row.setHeightToContent();
+        tab.balance.recovery.row.setPad(10, .column, .{});
+        tab.balance.recovery.row.setPad(8, .bottom, .{});
+        tab.balance.recovery.row.clearFlag(.scrollable);
+        _ = try lvgl.Spinner.new(tab.balance.recovery.row);
+        tab.balance.recovery.status = try lvgl.Label.new(
+            tab.balance.recovery.row,
+            "WALLET RECOVERY IN PROGRESS\nOn-chain balance may be incomplete.",
+            .{},
+        );
+        tab.balance.recovery.status.flexGrow(1);
+        tab.balance.recovery.row.hide();
+
         const row = try lvgl.FlexLayout.new(card, .row, .{});
         row.setWidth(lvgl.sizePercent(100));
         row.setHeightToContent();
@@ -137,6 +156,18 @@ pub fn updateTabPanel(rep: comm.Message.OnchainReport) !void {
     try tab.conn_out.setTextFmt(&buf, cmark ++ "CONNECTIONS OUT#\n{d}", .{rep.conn_out});
 
     // balance section
+    if (rep.lnd_recovery) |rec| {
+        const progress = @max(0, @min(100, rec.progress * 100));
+        tab.balance.recovery.row.show();
+        try tab.balance.recovery.status.setTextFmt(
+            &buf,
+            "WALLET RECOVERY IN PROGRESS\nOn-chain balance may be incomplete. {d:.2}%",
+            .{progress},
+        );
+    } else {
+        tab.balance.recovery.row.hide();
+    }
+
     if (rep.balance) |bal| {
         const confpct: f32 = pct: {
             if (bal.confirmed > bal.total) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wallet recovery progress to on-chain status reports.
  * Displayed a new “wallet recovery in progress” indicator in the balance view, including progress updates and a loading spinner.
* **Bug Fixes**
  * Recovery details now appear only when recovery is active, and are hidden otherwise.
  * Progress values are shown as a bounded percentage for clearer status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->