### PR TITLE
Handle wallet reset during lnd recovery

### DIFF
--- a/src/nd/Daemon.zig
+++ b/src/nd/Daemon.zig
@@ -1932,28 +1932,29 @@ test "daemon: start-poweroff" {
     try t.expect(daemon.state == .stopped);
     try t.expect(daemon.poweroff_thread == null);
     for (daemon.services.list) |*sv| {
-        try t.expect(sv.stop_proc.spawned);
-        try t.expect(sv.stop_proc.waited);
+        if (std.mem.eql(u8, sv.name, sys.Service.LND)) {
+            // LND is stopped through the dedicated `sv down lnd` path,
+            // not through SysService.stopWait().
+            try t.expect(!sv.stop_proc.spawned);
+            try t.expect(!sv.stop_proc.waited);
+        } else {
+            try t.expect(sv.stop_proc.spawned);
+            try t.expect(sv.stop_proc.waited);
+        }
         try t.expectEqual(sys.Service.Status.stopped, sv.status());
     }
 
     const msg1 = try comm.read(arena, gui_reader);
     try tt.expectDeepEqual(comm.Message{ .poweroff_progress = .{ .services = &.{
-        .{ .name = "lnd", .stopped = false, .err = null },
+        .{ .name = "lnd", .stopped = true, .err = null },
         .{ .name = "bitcoind", .stopped = false, .err = null },
     } } }, msg1.value);
 
     const msg2 = try comm.read(arena, gui_reader);
     try tt.expectDeepEqual(comm.Message{ .poweroff_progress = .{ .services = &.{
         .{ .name = "lnd", .stopped = true, .err = null },
-        .{ .name = "bitcoind", .stopped = false, .err = null },
-    } } }, msg2.value);
-
-    const msg3 = try comm.read(arena, gui_reader);
-    try tt.expectDeepEqual(comm.Message{ .poweroff_progress = .{ .services = &.{
-        .{ .name = "lnd", .stopped = true, .err = null },
         .{ .name = "bitcoind", .stopped = true, .err = null },
-    } } }, msg3.value);
+    } } }, msg2.value);
 
     // TODO: ensure "poweroff" was executed once custom runner is in a zig release;
     // need custom runner to set up a global registry for child processes.

--- a/src/nd/Daemon.zig
+++ b/src/nd/Daemon.zig
@@ -317,24 +317,16 @@ fn poweroffThread(self: *Daemon) void {
         logger.err("screen.backlight(.on) during poweroff: {any}", .{err});
     };
 
-    // initiate shutdown of all services concurrently.
+    // Stop services sequentially in dependency order. LND must fully stop
+    // before bitcoind is asked to shut down.
     for (self.services.list) |*sv| {
-        sv.stop() catch |err| logger.err("sv stop '{s}': {any}", .{ sv.name, err });
-    }
-    self.sendPoweroffReport() catch |err| logger.err("sendPoweroffReport: {any}", .{err});
-
-    // wait each service until stopped or error.
-    for (self.services.list) |*sv| {
-        sv.stopWait() catch |err| {
-            logger.warn("poweroff: stop {s} failed: {!}", .{ sv.name, err });
-            if (std.mem.eql(u8, sv.name, sys.Service.LND)) {
-                self.forceStopLndAfterTimeout("poweroff") catch |force_err| {
-                    logger.err("poweroff: force-stop lnd: {!}", .{force_err});
-                    continue;
-                };
-                sv.markStoppedSuccess();
-            }
-        };
+        if (std.mem.eql(u8, sv.name, sys.Service.LND)) {
+            self.stopLndForPoweroff(sv);
+        } else {
+            sv.stopWait() catch |err| {
+                logger.warn("poweroff: stop {s} failed: {!}", .{ sv.name, err });
+            };
+        }
         logger.info("{s} sv is now stopped; err={any}", .{ sv.name, sv.lastStopError() });
         self.sendPoweroffReport() catch |err| logger.err("sendPoweroffReport: {any}", .{err});
     }
@@ -343,6 +335,18 @@ fn poweroffThread(self: *Daemon) void {
     var off = types.ChildProcess.init(&.{"poweroff"}, self.allocator);
     const res = off.spawnAndWait();
     logger.info("poweroff: {any}", .{res});
+}
+
+fn stopLndForPoweroff(self: *Daemon, sv: *sys.Service) void {
+    self.runLndDownCheck(60) catch |err| {
+        logger.warn("poweroff: graceful lnd down failed: {!}; force-stopping", .{err});
+        self.forceStopLndAfterTimeout("poweroff") catch |force_err| {
+            logger.err("poweroff: force-stop lnd: {!}", .{force_err});
+            sv.markStoppedError(force_err);
+            return;
+        };
+    };
+    sv.markStoppedSuccess();
 }
 
 /// main thread entry point: watches for want_xxx flags and monitors network.
@@ -1492,16 +1496,16 @@ fn initWallet(self: *Daemon, req: comm.Message.LightningInitWallet) !void {
 /// out while LND is in the middle of a wallet recovery rescan; in that case,
 /// escalate and then re-check the service state instead of failing immediately.
 fn stopLndForReset(self: *Daemon) !void {
-    self.services.stopWait(sys.Service.LND) catch |err| {
-        logger.warn("resetLndNode: graceful lnd stop failed: {!}; force-stopping", .{err});
+    self.runLndDownCheck(60) catch |err| {
+        logger.warn("resetLndNode: graceful lnd down failed: {!}; force-stopping", .{err});
         try self.forceStopLndAfterTimeout("resetLndNode");
-        for (self.services.list) |*sv| {
-            if (std.mem.eql(u8, sv.name, sys.Service.LND)) {
-                sv.markStoppedSuccess();
-                break;
-            }
-        }
     };
+    for (self.services.list) |*sv| {
+        if (std.mem.eql(u8, sv.name, sys.Service.LND)) {
+            sv.markStoppedSuccess();
+            break;
+        }
+    }
 }
 
 fn forceStopLndAfterTimeout(self: *Daemon, context: []const u8) !void {

--- a/src/nd/Daemon.zig
+++ b/src/nd/Daemon.zig
@@ -325,7 +325,16 @@ fn poweroffThread(self: *Daemon) void {
 
     // wait each service until stopped or error.
     for (self.services.list) |*sv| {
-        _ = sv.stopWait() catch {};
+        sv.stopWait() catch |err| {
+            logger.warn("poweroff: stop {s} failed: {!}", .{ sv.name, err });
+            if (std.mem.eql(u8, sv.name, sys.Service.LND)) {
+                self.forceStopLndAfterTimeout("poweroff") catch |force_err| {
+                    logger.err("poweroff: force-stop lnd: {!}", .{force_err});
+                    continue;
+                };
+                sv.markStoppedSuccess();
+            }
+        };
         logger.info("{s} sv is now stopped; err={any}", .{ sv.name, sv.lastStopError() });
         self.sendPoweroffReport() catch |err| logger.err("sendPoweroffReport: {any}", .{err});
     }
@@ -1485,18 +1494,27 @@ fn initWallet(self: *Daemon, req: comm.Message.LightningInitWallet) !void {
 fn stopLndForReset(self: *Daemon) !void {
     self.services.stopWait(sys.Service.LND) catch |err| {
         logger.warn("resetLndNode: graceful lnd stop failed: {!}; force-stopping", .{err});
+        try self.forceStopLndAfterTimeout("resetLndNode");
+        for (self.services.list) |*sv| {
+            if (std.mem.eql(u8, sv.name, sys.Service.LND)) {
+                sv.markStoppedSuccess();
+                break;
+            }
+        }
+    };
+}
 
-        self.runLndStopCommand("force-stop") catch |force_err| {
-            logger.warn("resetLndNode: sv force-stop lnd failed: {!}", .{force_err});
-        };
+fn forceStopLndAfterTimeout(self: *Daemon, context: []const u8) !void {
+    self.runLndStopCommand("force-stop") catch |force_err| {
+        logger.warn("{s}: sv force-stop lnd failed: {!}", .{ context, force_err });
+    };
 
-        // sv force-stop sends a KILL on timeout, but can still exit non-zero if
-        // the service has not observed the state transition yet. Give runit one
-        // more short down check before using a direct pid kill fallback.
-        self.runLndDownCheck(10) catch |down_err| {
-            logger.warn("resetLndNode: lnd still not down after force-stop: {!}; killing pid", .{down_err});
-            try self.killLndPidAndWaitDown();
-        };
+    // sv force-stop sends a KILL on timeout, but can still exit non-zero if
+    // the service has not observed the state transition yet. Give runit one
+    // more short down check before using a direct pid kill fallback.
+    self.runLndDownCheck(10) catch |down_err| {
+        logger.warn("{s}: lnd still not down after force-stop: {!}; killing pid", .{ context, down_err });
+        try self.killLndPidAndWaitDown();
     };
 }
 

--- a/src/nd/Daemon.zig
+++ b/src/nd/Daemon.zig
@@ -1055,6 +1055,10 @@ fn processLndReportError(self: *Daemon, err: anyerror) !void {
 
     switch (err) {
         error.ConnectionRefused => {
+            // LND may stay down for a while during wallet reset/recovery.
+            // Do not spin on an immediate report request every main-loop tick.
+            self.lnd_timer.reset();
+            self.want_lnd_report = false;
             return comm.write(self.allocator, self.uiwriter, msg_starting);
         },
 
@@ -1094,6 +1098,8 @@ fn processLndReportError(self: *Daemon, err: anyerror) !void {
     const status = client.call(.walletstatus, {}) catch |err2| {
         return switch (err2) {
             error.ConnectionRefused => {
+                self.lnd_timer.reset();
+                self.want_lnd_report = false;
                 try comm.write(self.allocator, self.uiwriter, msg_starting);
             },
             error.TlsInitializationFailed => {
@@ -1473,6 +1479,68 @@ fn initWallet(self: *Daemon, req: comm.Message.LightningInitWallet) !void {
     self.mu.unlock();
 }
 
+/// Stops LND for a destructive wallet reset. The normal service stop can time
+/// out while LND is in the middle of a wallet recovery rescan; in that case,
+/// escalate and then re-check the service state instead of failing immediately.
+fn stopLndForReset(self: *Daemon) !void {
+    self.services.stopWait(sys.Service.LND) catch |err| {
+        logger.warn("resetLndNode: graceful lnd stop failed: {!}; force-stopping", .{err});
+
+        self.runLndStopCommand("force-stop") catch |force_err| {
+            logger.warn("resetLndNode: sv force-stop lnd failed: {!}", .{force_err});
+        };
+
+        // sv force-stop sends a KILL on timeout, but can still exit non-zero if
+        // the service has not observed the state transition yet. Give runit one
+        // more short down check before using a direct pid kill fallback.
+        self.runLndDownCheck(10) catch |down_err| {
+            logger.warn("resetLndNode: lnd still not down after force-stop: {!}; killing pid", .{down_err});
+            try self.killLndPidAndWaitDown();
+        };
+    };
+}
+
+fn runLndStopCommand(self: *Daemon, command: []const u8) !void {
+    var proc = types.ChildProcess.init(&.{ "sv", command, sys.Service.LND }, self.allocator);
+    const term = try proc.spawnAndWait();
+    switch (term) {
+        .Exited => |code| if (code != 0) return Error.LndServiceStopFail,
+        else => return Error.LndServiceStopFail,
+    }
+}
+
+fn runLndDownCheck(self: *Daemon, wait_sec: u32) !void {
+    const wait_arg = try std.fmt.allocPrint(self.allocator, "{d}", .{wait_sec});
+    defer self.allocator.free(wait_arg);
+
+    var proc = types.ChildProcess.init(&.{ "sv", "-w", wait_arg, "down", sys.Service.LND }, self.allocator);
+    const term = try proc.spawnAndWait();
+    switch (term) {
+        .Exited => |code| if (code != 0) return Error.LndServiceStopFail,
+        else => return Error.LndServiceStopFail,
+    }
+}
+
+fn killLndPidAndWaitDown(self: *Daemon) !void {
+    // Last-resort reset-only fallback. runit normally owns signal delivery, but
+    // during wallet recovery LND can get wedged in shutdown after TERM. Parse the
+    // supervised pid from `sv status`, SIGKILL it, then wait for runit to observe
+    // the service as down before deleting wallet data.
+    var kill = types.ChildProcess.init(&.{
+        "sh",
+        "-c",
+        "pid=$(sv status lnd 2>/dev/null | sed -n 's/^run: .*: (pid \\([0-9][0-9]*\\)).*/\\1/p'); " ++
+            "if [ -n \"$pid\" ]; then kill -9 \"$pid\" 2>/dev/null || true; fi",
+    }, self.allocator);
+    const kill_term = try kill.spawnAndWait();
+    switch (kill_term) {
+        .Exited => |code| if (code != 0) return Error.LndServiceStopFail,
+        else => return Error.LndServiceStopFail,
+    }
+
+    try self.runLndDownCheck(10);
+}
+
 /// factory-resets lnd node; wipes out the wallet.
 fn resetLndNode(self: *Daemon) !void {
     self.mu.lock();
@@ -1499,23 +1567,29 @@ fn resetLndNode(self: *Daemon) !void {
     self.state = .wallet_reset;
     self.mu.unlock();
 
-    // 1. stop lnd service
+    // 1. stop lnd service. A wallet recovery rescan can make graceful stop take
+    // longer than usual; if runit times out, force-stop before deleting data.
     logger.info("resetLndNode: stopping lnd", .{});
-    try self.services.stopWait(sys.Service.LND);
+    try self.stopLndForReset();
 
     // 2. delete all data directories
     logger.info("resetLndNode: deleting lnd data", .{});
     try std.fs.cwd().deleteTree(Config.LND_DATA_DIR);
     try std.fs.cwd().deleteTree(Config.LND_LOG_DIR);
+    if (std.fs.path.dirname(Config.LND_TLSCERT_PATH)) |dir| {
+        try std.fs.cwd().deleteTree(dir);
+    }
+    // TODO: reset tor hidden service pubkey?
+
+    // Cancel any pending restore resume after old wallet data is gone. If data
+    // deletion fails, keep these files so a later restart still resumes the old
+    // wallet recovery path instead of leaving old data without its recovery state.
+    logger.info("resetLndNode: clearing lnd recovery files", .{});
     std.fs.cwd().deleteFile(Config.LND_WALLETUNLOCK_PATH) catch |err| switch (err) {
         error.FileNotFound => {},
         else => return err,
     };
     try Config.deleteLndRecoveryWindowFile();
-    if (std.fs.path.dirname(Config.LND_TLSCERT_PATH)) |dir| {
-        try std.fs.cwd().deleteTree(dir);
-    }
-    // TODO: reset tor hidden service pubkey?
 
     // 3. generate a new blank config so lnd can start up again and respond
     // to status requests.

--- a/src/sys/Service.zig
+++ b/src/sys/Service.zig
@@ -87,6 +87,14 @@ pub fn markStoppedSuccess(self: *SysService) void {
     self.stop_err = null;
 }
 
+/// records that an external stop fallback failed.
+pub fn markStoppedError(self: *SysService, err: anyerror) void {
+    self.mu.lock();
+    defer self.mu.unlock();
+
+    self.stop_err = err;
+}
+
 /// launches a service start procedure and returns as soon as the startup script
 /// terminates: whether the service actually started successefully is not necessarily
 /// indicated by the function return.

--- a/src/sys/Service.zig
+++ b/src/sys/Service.zig
@@ -78,6 +78,15 @@ pub fn lastStopError(self: *SysService) ?anyerror {
     return self.stop_err;
 }
 
+/// marks a service as successfully stopped after an external stop fallback.
+pub fn markStoppedSuccess(self: *SysService) void {
+    self.mu.lock();
+    defer self.mu.unlock();
+
+    self.stat = .{ .stopped = .{ .Exited = 0 } };
+    self.stop_err = null;
+}
+
 /// launches a service start procedure and returns as soon as the startup script
 /// terminates: whether the service actually started successefully is not necessarily
 /// indicated by the function return.

--- a/src/sys/Service.zig
+++ b/src/sys/Service.zig
@@ -92,6 +92,7 @@ pub fn markStoppedError(self: *SysService, err: anyerror) void {
     self.mu.lock();
     defer self.mu.unlock();
 
+    self.stat = .stopping;
     self.stop_err = err;
 }
 

--- a/src/ui/poweroff.zig
+++ b/src/ui/poweroff.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const comm = @import("../comm.zig");
 const lvgl = @import("lvgl.zig");
 const symbol = @import("symbol.zig");
+const sys = @import("../sys/Service.zig");
 const widget = @import("widget.zig");
 
 const logger = std.log.scoped(.ui);
@@ -41,6 +42,11 @@ fn poweroffModalCallback(btn_idx: usize) align(@alignOf(widget.ModalButtonCallba
         logger.err("ProgressWin.create: {any}", .{err});
         return;
     };
+    if (global_progress_win) |win| {
+        win.showInitialServices() catch |err| {
+            logger.err("ProgressWin.showInitialServices: {any}", .{err});
+        };
+    }
 }
 
 var global_progress_win: ?ProgressWin = null;
@@ -98,6 +104,12 @@ const ProgressWin = struct {
 
     fn resetSvContainer(self: ProgressWin) void {
         self.svcont.deleteChildren();
+    }
+
+    fn showInitialServices(self: ProgressWin) !void {
+        self.resetSvContainer();
+        try self.addServiceStatus(sys.LND, false, null);
+        try self.addServiceStatus(sys.BITCOIND, false, null);
     }
 
     fn addServiceStatus(self: ProgressWin, name: []const u8, stopped: bool, err: ?[]const u8) !void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved poweroff shutdown ordering so dependent services stop sequentially, with failures handled more gracefully.
  * Enhanced “not ready” handling after connection refusals, preventing repeated immediate LND status/report attempts.
  * Made destructive LND resets more reliable, including stronger escalation when shutdown doesn’t complete and a safer cleanup order.
* **New Features**
  * The poweroff progress UI now initializes with baseline service rows (e.g., LND and BITCOIND).
  * Added the ability to explicitly record stop outcomes for services (success/error).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->